### PR TITLE
Switch from crc-32 to murmur2 partition key hashing

### DIFF
--- a/lib/rdkafka/bindings.rb
+++ b/lib/rdkafka/bindings.rb
@@ -235,14 +235,14 @@ module Rdkafka
     attach_function :rd_kafka_conf_set_dr_msg_cb, [:pointer, :delivery_cb], :void
 
     # Partitioner
-    attach_function :rd_kafka_msg_partitioner_consistent_random, [:pointer, :pointer, :size_t, :int32, :pointer, :pointer], :int32
+    attach_function :rd_kafka_msg_partitioner_murmur2_random, [:pointer, :pointer, :size_t, :int32, :pointer, :pointer], :int32
 
     def self.partitioner(str, partition_count)
       # Return RD_KAFKA_PARTITION_UA(unassigned partition) when partition count is nil/zero.
       return -1 unless partition_count&.nonzero?
 
       str_ptr = FFI::MemoryPointer.from_string(str)
-      rd_kafka_msg_partitioner_consistent_random(nil, str_ptr, str.size, partition_count, nil, nil)
+      rd_kafka_msg_partitioner_murmur2_random(nil, str_ptr, str.size, partition_count, nil, nil)
     end
 
     # Create Topics

--- a/lib/rdkafka/version.rb
+++ b/lib/rdkafka/version.rb
@@ -1,5 +1,5 @@
 module Rdkafka
-  VERSION = "0.8.1"
+  VERSION = "0.8.1.beta-murmur"
   LIBRDKAFKA_VERSION = "1.4.0"
   LIBRDKAFKA_SOURCE_SHA256 = "ae27ea3f3d0d32d29004e7f709efbba2666c5383a107cc45b3a1949486b2eb84"
 end


### PR DESCRIPTION
Patch to use `murmur2` for computing destination partition.

Do not merge